### PR TITLE
Updated to v3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v3.3.2
+###### July 17, 2025
+*   Fixed an issue where reactions wouldn't be cleared properly if the Discord member prevented direct messages after being granted a reaction role.
+*   Fixed an issue where a reaction would be removed on the first attempt of adding reaction roles to a Discord message.
+
 ## v3.3.1
 ###### July 11, 2025
 *   Added a configuration `.env` setting to determine when a Twitch embed would be "timed-out" and become offline/removed.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# THPSBot v3.3.1
+# THPSBot v3.3.2
 
 ## What is this!?
 THPSBot is a bot for the [THPS Speedrun Discord](https://thps.run/discord). It is a bot specially designed by [ThePackle](https://twitter.com/thepackle) that combines multiple functions. This includes:

--- a/thpsbot/modules/roleassigner.py
+++ b/thpsbot/modules/roleassigner.py
@@ -80,6 +80,7 @@ class RoleCog(Cog, name="Roles", description="Manages THPSBot's reaction message
                 return
 
             message_id = await interaction.channel.fetch_message(int(message))
+            await asyncio.sleep(0.5)
             await message_id.add_reaction(emoji)
 
             try:
@@ -174,15 +175,24 @@ class RoleCog(Cog, name="Roles", description="Manages THPSBot's reaction message
 
         if role in member.roles:
             await member.remove_roles(role)
-            await member.send(
-                f"{role.name} role was removed from your profile successfully in {guild.name}."
-            )
+
+            try:
+                await member.send(
+                    f"{role.name} role was removed from your profile successfully in {guild.name}."
+                )
+            except Exception:
+                pass
+
             await asyncio.sleep(0.5)
         else:
             await member.add_roles(role)
-            await member.send(
-                f"{role.name} role was added to your profile successfully in {guild.name}."
-            )
+            try:
+                await member.send(
+                    f"{role.name} role was added to your profile successfully in {guild.name}."
+                )
+            except discord.Forbidden:
+                pass
+
             await asyncio.sleep(0.5)
 
         await message.remove_reaction(payload.emoji, member)


### PR DESCRIPTION
*   Fixed an issue where reactions wouldn't be cleared properly if the Discord member prevented direct messages after being granted a reaction role.
*   Fixed an issue where a reaction would be removed on the first attempt of adding reaction roles to a Discord message.
