### PR TITLE
v4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v4.2
+###### June 7, 2026
+*   Added time delta to the `Reign Duration` portion of approved embeds.
+*   Added buttons to take you to Speedrun.com and thps.run (thps.run is now the default/first link seen).
+    *   Submissions will take you to the thps.run or SRC hubs.
+
+*   Fixed an issue where `approver` was not forwarded to the thps.run API, resulting in no approver being associated with the run.
+
+* * *
+
 ## v4.1
 ###### June 6, 2026
 *   Added a new `Reign Duration` function that, if a run is the WR, will show the length of time elapsed since the last WR.

--- a/thpsbot/helpers/duration_helper.py
+++ b/thpsbot/helpers/duration_helper.py
@@ -32,3 +32,19 @@ def format_reign(
         return phrase or "less than a minute"
 
     return _join_parts([(rd.years, "year"), (rd.months, "month"), (rd.days, "day")])
+
+
+def format_gap(
+    seconds: float,
+) -> str:
+    """Compact 'Xh Ym Zs Wms' magnitude of a delta, dropping zero parts ("" if zero)."""
+    total_ms = int(round(abs(seconds) * 1000))
+    hours, rem = divmod(total_ms, 3_600_000)
+    minutes, rem = divmod(rem, 60_000)
+    secs, ms = divmod(rem, 1000)
+    parts = [
+        f"{value}{suffix}"
+        for value, suffix in ((hours, "h"), (minutes, "m"), (secs, "s"), (ms, "ms"))
+        if value
+    ]
+    return " ".join(parts)

--- a/thpsbot/helpers/embed_helper.py
+++ b/thpsbot/helpers/embed_helper.py
@@ -11,7 +11,11 @@ from thpsbot.helpers.config_helper import (
     THPS_RUN_SITE,
     TTV_TIMEOUT,
 )
+from thpsbot.helpers.thpsrun_helper import THPSRunHelper
 from thpsbot.models import PlayerRunInline
+
+SRC_EMOJI = discord.PartialEmoji(name="src", id=1391867987157319882)
+THPSRUN_EMOJI = discord.PartialEmoji(name="thpsrun", id=1391866542500872382)
 
 THPS_RUN = THPS_RUN_SITE
 load_dotenv()
@@ -46,12 +50,13 @@ class EmbedCreator:
         approval: str | None,
         obsolete: bool,
         wr_reign: str | None = None,
-    ) -> Embed:
+        board_url: str | None = None,
+    ) -> tuple[Embed, discord.ui.View]:
         pfp = _pfp_icon(player_pfp)
 
         embed = Embed(
             title=title,
-            url=url,
+            url=board_url or url,
             color=random.randint(0, 0xFFFFFF),
         )
         if approval:
@@ -80,7 +85,24 @@ class EmbedCreator:
         if description:
             embed.add_field(name="Comments", value=description[:1024], inline=False)
 
-        return embed
+        view = discord.ui.View()
+        if board_url:
+            view.add_item(
+                discord.ui.Button(
+                    label="thps.run",
+                    url=board_url,
+                    emoji=THPSRUN_EMOJI,
+                )
+            )
+        view.add_item(
+            discord.ui.Button(
+                label="Speedrun.com",
+                url=url,
+                emoji=SRC_EMOJI,
+            )
+        )
+
+        return embed, view
 
     @staticmethod
     def submission_embed(
@@ -93,7 +115,7 @@ class EmbedCreator:
         run_type: str,
         submitted: str | None,
         warnings: list | None,
-    ) -> Embed:
+    ) -> tuple[Embed, discord.ui.View]:
         pfp = _pfp_icon(player_pfp)
 
         embed = Embed(
@@ -110,18 +132,6 @@ class EmbedCreator:
 
         embed.description = f"{subcategory}\nTime: {time} ({run_type})"
 
-        embed.add_field(
-            name="thps.run",
-            value="[Submissions](https://thps.run/submissions)",
-            inline=True,
-        )
-
-        embed.add_field(
-            name="Speedrun.com",
-            value=f"[Run Page]({url})",
-            inline=True,
-        )
-
         if warnings:
             for warning in warnings:
                 embed.add_field(
@@ -130,7 +140,23 @@ class EmbedCreator:
                     inline=False,
                 )
 
-        return embed
+        view = discord.ui.View()
+        view.add_item(
+            discord.ui.Button(
+                label="Submissions",
+                url="https://thps.run/submissions",
+                emoji=THPSRUN_EMOJI,
+            )
+        )
+        view.add_item(
+            discord.ui.Button(
+                label="SRC Hub",
+                url=url,
+                emoji=SRC_EMOJI,
+            )
+        )
+
+        return embed, view
 
     @staticmethod
     def player_embed(
@@ -167,7 +193,10 @@ class EmbedCreator:
         embed.add_field(name="Total Runs", value=total_runs or 0, inline=True)
         embed.set_footer(text=BOT)
 
-        def _render(runs: list[PlayerRunInline], header: str) -> None:
+        def _render(
+            runs: list[PlayerRunInline],
+            header: str,
+        ) -> None:
             if not runs:
                 return
             embed.add_field(name=header, value="", inline=False)
@@ -178,9 +207,19 @@ class EmbedCreator:
                 elif game == "THPS12":
                     game = "THPS1+2"
                 subcat = run.subcategory or ""
+                label = f"{game} - {subcat} in {run.time}"
+                board = THPSRunHelper.build_leaderboard_url_inline(run)
+                if board and run.url:
+                    line = f"{index}. [{label}]({board}) ([SRC]({run.url}))"
+                elif board:
+                    line = f"{index}. [{label}]({board})"
+                elif run.url:
+                    line = f"{index}. [{label}]({run.url})"
+                else:
+                    line = f"{index}. {label}"
                 embed.add_field(
                     name="",
-                    value=f"{index}. [{game} - {subcat} in {run.time}]({run.url})",
+                    value=line,
                     inline=False,
                 )
 
@@ -235,7 +274,7 @@ class EmbedCreator:
                 discord.ui.Button(
                     label="Speedrun.com",
                     url=f"https://speedrun.com/{src_username}",
-                    emoji=discord.PartialEmoji(name="src", id=1391867987157319882),
+                    emoji=SRC_EMOJI,
                 )
             )
 
@@ -243,7 +282,7 @@ class EmbedCreator:
                 discord.ui.Button(
                     label="thps.run",
                     url=f"https://thps.run/player/{src_username}",
-                    emoji=discord.PartialEmoji(name="thpsrun", id=1391866542500872382),
+                    emoji=THPSRUN_EMOJI,
                 )
             )
 

--- a/thpsbot/helpers/thpsrun_helper.py
+++ b/thpsbot/helpers/thpsrun_helper.py
@@ -6,8 +6,9 @@ from typing import TYPE_CHECKING, Any
 
 from thpsbot.helpers.aiohttp_helper import AIOHTTPHelper
 from thpsbot.helpers.config_helper import THPS_RUN_API, THPS_RUN_SITE
-from thpsbot.helpers.duration_helper import format_reign
+from thpsbot.helpers.duration_helper import format_gap, format_reign
 from thpsbot.models import (
+    PlayerRunInline,
     THPSRunCategory,
     THPSRunGame,
     THPSRunHistory,
@@ -218,6 +219,73 @@ class THPSRunHelper:
         return slugs
 
     @staticmethod
+    async def build_leaderboard_url(
+        bot: "THPSBot",
+        run: THPSRunRuns,
+    ) -> str | None:
+        """Build the thps.run frontend leaderboard URL for a run, or None.
+
+        Resolves the run's game/category/level slugs and variable value-slugs into the public
+        leaderboard URL (the same board the run lives on). Value-slugs are emitted in the order the
+        API returns them.
+
+        Arguments:
+            bot (THPSBot): The running bot instance (for the API auth header).
+            run (THPSRunRuns): A run with embedded game/category/level objects.
+
+        Returns:
+            url (str | None): The frontend leaderboard URL, or None if unbuildable.
+        """
+        game = run.game if isinstance(run.game, THPSRunGame) else None
+        category = run.category if isinstance(run.category, THPSRunCategory) else None
+        if not (game and game.slug and category and category.slug):
+            return None
+        level = run.level if isinstance(run.level, THPSRunLevel) else None
+
+        slugs = await THPSRunHelper._resolve_value_slugs(bot, run)
+        if slugs is None:
+            return None
+
+        if level and level.slug:
+            path = f"{game.slug}/ils/{level.slug}/{category.slug}"
+        else:
+            path = f"{game.slug}/{category.slug}"
+        if slugs:
+            path += "/" + "/".join(slugs)
+
+        return f"{THPS_RUN_SITE}/{path}"
+
+    @staticmethod
+    def build_leaderboard_url_inline(
+        run: PlayerRunInline,
+    ) -> str | None:
+        """Build the thps.run leaderboard URL from an inline player-run object.
+
+        Uses the slugs and ordered value_slugs already present in the player-runs payload, so it
+        performs no API calls. Returns None when a required slug is missing.
+
+        Arguments:
+            run (PlayerRunInline): A recent-run entry from a player payload.
+
+        Returns:
+            url (str | None): The frontend leaderboard URL, or None if unbuildable.
+        """
+        game_slug = run.game.slug if run.game else None
+        category_slug = run.category.slug if run.category else None
+        if not (game_slug and category_slug):
+            return None
+        level_slug = run.level.slug if run.level else None
+
+        if level_slug:
+            path = f"{game_slug}/ils/{level_slug}/{category_slug}"
+        else:
+            path = f"{game_slug}/{category_slug}"
+        if run.value_slugs:
+            path += "/" + "/".join(run.value_slugs)
+
+        return f"{THPS_RUN_SITE}/{path}"
+
+    @staticmethod
     async def get_wr_reign(
         bot: "THPSBot",
         run: THPSRunRuns,
@@ -290,9 +358,18 @@ class THPSRunHelper:
             else:
                 time_part = ""
 
+            gap = ""
+            r_secs = run.times.p_time_secs
+            if r_secs is not None and prev.history_time_secs is not None:
+                diff = r_secs - prev.history_time_secs
+                if diff < 0:
+                    formatted = format_gap(diff)
+                    if formatted:
+                        gap = f" [-{formatted}]"
+
             return (
-                f"-# Last WR Holder: {holder}{time_part} | "
-                f"{name}'s record lasted {format_reign(start, end)}"
+                f"\n-# Last WR Holder: {holder}{time_part}{gap}"
+                f"\n-# The last record lasted {format_reign(start, end)}."
             )
         except Exception as e:
             _log.warning("get_wr_reign failed for %s", run.id, exc_info=e)

--- a/thpsbot/modules/thpsrun.py
+++ b/thpsbot/modules/thpsrun.py
@@ -137,18 +137,21 @@ class THPSRunCog(
                     warnings = await THPSRunHelper.get_import_issues(self.bot, run.id)
                     player_pfp = await self._fetch_player_pfp(run)
 
+                    board_url = await THPSRunHelper.build_leaderboard_url(self.bot, run)
+                    embed, view = EmbedCreator.submission_embed(
+                        title=run_data.embed_title,
+                        subcategory=run.subcategory,
+                        url=run.url,
+                        player=run_data.players,
+                        player_pfp=player_pfp,
+                        time=run_data.time,
+                        run_type=run_data.run_type,
+                        submitted=run.date,
+                        warnings=warnings,
+                    )
                     embed_msg = await self.submit_channel.send(
-                        embed=EmbedCreator.submission_embed(
-                            title=run_data.embed_title,
-                            subcategory=run.subcategory,
-                            url=run.url,
-                            player=run_data.players,
-                            player_pfp=player_pfp,
-                            time=run_data.time,
-                            run_type=run_data.run_type,
-                            submitted=run.date,
-                            warnings=warnings,
-                        )
+                        embed=embed,
+                        view=view,
                     )
 
                     self.submissions.update(
@@ -221,25 +224,31 @@ class THPSRunCog(
                     )
                     player_pfp = await self._fetch_player_pfp(run_verify)
 
+                    board_url = await THPSRunHelper.build_leaderboard_url(
+                        self.bot, run_verify
+                    )
+                    embed, view = EmbedCreator.approved_embed(
+                        title=run_data.embed_title,
+                        subcategory=run_verify.subcategory or "",
+                        url=run_verify.url,
+                        player=run_data.players,
+                        player_pfp=player_pfp,
+                        placement=run_verify.place,
+                        points=run_verify.points or 0,
+                        platform=platform_name,
+                        time=run_data.time,
+                        time_delta=time_delta,
+                        completed_runs=None,
+                        run_type=run_data.run_type,
+                        description=run_verify.description,
+                        approval=run_verify.v_date,
+                        obsolete=run_verify.obsolete,
+                        wr_reign=wr_reign,
+                        board_url=board_url,
+                    )
                     await self.pb_channel.send(
-                        embed=EmbedCreator.approved_embed(
-                            title=run_data.embed_title,
-                            subcategory=run_verify.subcategory or "",
-                            url=run_verify.url,
-                            player=run_data.players,
-                            player_pfp=player_pfp,
-                            placement=run_verify.place,
-                            points=run_verify.points or 0,
-                            platform=platform_name,
-                            time=run_data.time,
-                            time_delta=time_delta,
-                            completed_runs=None,
-                            run_type=run_data.run_type,
-                            description=run_verify.description,
-                            approval=run_verify.v_date,
-                            obsolete=run_verify.obsolete,
-                            wr_reign=wr_reign,
-                        )
+                        embed=embed,
+                        view=view,
                     )
 
                     embed_msg = await self.submit_channel.fetch_message(
@@ -449,24 +458,28 @@ class THPSRunCog(
 
                     player_pfp = await self._fetch_player_pfp(run)
 
+                    board_url = await THPSRunHelper.build_leaderboard_url(self.bot, run)
+                    embed, view = EmbedCreator.approved_embed(
+                        title=run_data.embed_title,
+                        subcategory=run.subcategory,
+                        url=run.url,
+                        player=run_data.players,
+                        player_pfp=player_pfp,
+                        placement=run.place,
+                        points=run.points or 0,
+                        platform=platform_name,
+                        time=run_data.time,
+                        time_delta=time_delta,
+                        completed_runs=None,
+                        run_type=run_data.run_type,
+                        description=run.description,
+                        approval=run.v_date,
+                        obsolete=run.obsolete,
+                        board_url=board_url,
+                    )
                     await interaction.response.send_message(
-                        embed=EmbedCreator.approved_embed(
-                            title=run_data.embed_title,
-                            subcategory=run.subcategory,
-                            url=run.url,
-                            player=run_data.players,
-                            player_pfp=player_pfp,
-                            placement=run.place,
-                            points=run.points or 0,
-                            platform=platform_name,
-                            time=run_data.time,
-                            time_delta=time_delta,
-                            completed_runs=None,
-                            run_type=run_data.run_type,
-                            description=run.description,
-                            approval=run.v_date,
-                            obsolete=run.obsolete,
-                        )
+                        embed=embed,
+                        view=view,
                     )
             else:
                 await interaction.response.send_message(
@@ -523,6 +536,7 @@ class THPSRunCog(
                     else "new"
                 ),
                 "place": 999,
+                "approver_id": src.status.examiner,
                 "variable_values": src.values,
                 "description": src.comment,
             }


### PR DESCRIPTION
## v4.2
###### June 7, 2026
*   Added time delta to the `Reign Duration` portion of approved embeds.
*   Added buttons to take you to Speedrun.com and thps.run (thps.run is now the default/first link seen).
    *   Submissions will take you to the thps.run or SRC hubs.

*   Fixed an issue where `approver` was not forwarded to the thps.run API, resulting in no approver being associated with the run.
